### PR TITLE
ADR-002

### DIFF
--- a/adr/adr-002.md
+++ b/adr/adr-002.md
@@ -1,0 +1,342 @@
+# ADR-002: Liquid Staking Module
+
+## Abstract
+
+The LSM is designed to safely and efficiently facilitate the adoption of liquid staking.
+
+The LSM mitigates liquid staking risks by limiting the total amount of tokens that can be liquid staked to 30% of all staked tokens. 
+
+As an additional risk-mitigation feature, the LSM introduces a requirement that validators self-bond tokens to be eligible for delegations from liquid staking providers.
+
+## Context 
+
+Liquid proof of stake systems  exacerbate the risk that a single entity - the liquid staking provider - amasses more than ⅓ the total staked supply on a given chain, giving it the power to halt that chain’s block production or censor transactions and proposals.
+
+Liquid proof of stake may also exacerbates the principal agent risk that exists at the heart of the delegated proof of stake system. The core of the problem is that validators do not actually own the stake that is delegated to them. This leaves the open to perverse incentives to attack the consensus system. Cosmos introduced the idea of min self bond in the staking. This creates a minimum amount of stake the must be bonded by the validators operator key. This feature has very little effect on the behavior of delegates.
+
+
+## Proposal:
+
+
+### Limiting liquid staking
+
+
+The LSM would limit the percentage of liquid staked tokens by all liquid staking providers to 30% of the total supply of staked tokens. For example, if 222.76M tokens were currently staked, and if the LSM were installed today then the total liquid staked supply would be limited to a maximum of 66.83M tokens.
+
+This is a key safety feature, as it would prevent liquid staking providers from collectively controlling more than ⅓ of the total staked token supply, which is the threshold at which a group of bad actors could halt block production.
+
+Technically speaking, this cap on liquid staked tokens is enforced by limiting the total number of tokens that can be staked via interchain accounts plus the number of tokens that can be tokenized using LSM. Once this joint cap is reached, the LSM prevents interchain accounts from staking any more tokens and prevents tokenization of delegations using LSM.
+
+
+### Validator self-bond
+
+As an additional security feature, validators who want to receive delegations from liquid staking providers would be required to self-bond a certain amount of tokens. The validator self-bond, or “validator-bond,” means that validators need to have “skin in the game” in order to be entrusted with delegations from liquid staking providers. This disincentivizes malicious behavior and enables the validator to negotiate its relationship with liquid staking providers.
+
+Technically speaking, the validator-bond is tracked by the LSM. The maximum number of tokens that can be delegated to a validator by a liquid staking provider is equal to the validator-bond multiplied by the “validator-bond factor.” The initial validator bond factor would be set at 250, but can be configured by governance. 
+
+With a validator-bond factor of 250, for every 1 token a validator self-bonds, that validator is eligible to receive up to two-hundred-and-fifty tokens delegated from liquid staking providers. The validator-bond has no impact on anything other than eligibility for delegations from liquid staking providers.
+
+Without self-bonding tokens, a validator can’t receive delegations from liquid staking providers. And if a validator’s maximum amount of delegated tokens from liquid staking providers has been met, it would have to self-bond more tokens to become eligible for additional liquid staking provider delegations.
+
+### Instantly liquid staking tokens that are already staked
+
+Next, let’s discuss how the LSM makes the adoption of liquid staking more efficient, and can help the blockchain that installs it build strong relationships with liquid staking providers. The LSM enables users to instantly liquid stake their staked tokens, without having to wait the twenty-one day unbonding period. This is important, because a very large portion of the token supply on most Cosmos blockchains is currently staked. Liquid staking tokens that are already staked incur a switching cost in the form of three weeks’ forfeited staking rewards. The LSM eliminates this switching cost.
+
+
+A user would be able to visit any liquid staking provider that has integrated with the LSM and click a button to convert his staked tokens to liquid staked tokens. It would be as easy as liquid staking unstaked tokens.
+
+Technically speaking, this is accomplished by using something called an “LSM share.” Using the liquid staking module, a user can tokenize their staked tokens and turn it into LSM shares. LSM shares can be redeemed for underlying staked tokens and are transferable. After staked tokens are tokenized they can be immediately transferred to a liquid staking provider in exchange for liquid staking tokens - without having to wait for the unbonding period.
+
+
+## Economics:
+
+We expect that eventually governance may decide that the principal agent problems between validators and liquid staking are resolved through the existence of mature liquid staking synthetic asset systems and their associate risk framework. Governance can effectively disable the feature by setting the scalar value to -1 and allow unlimited minting and all liquid delegations to be freely undelegated.
+
+During the transitionary period, this creates a market for liquid shares that may serve to help further decentralize the validator set.
+
+It also allows multiple participants in a validator business to hold their personal stakes in segregated accounts but all collectively contribute towards demonstrating alignment with the safety of the protocol.
+
+
+## Technical Spec
+
+### Modification from ADR-001 
+ADR-002 introduces the global liquid staking cap and renames exemption factor to validator bond factor. Delegations from module account and LSM tokenized shares are tracked against the global liquid staking and validator bond caps. This requires changing the standard staking transactions to introspect. The reason for tracking module account shares is because ICAs are module accounts under the hood, so in practice this limits liquid staking.
+
+### Instructions for validators
+Once delegated to a validator, a delegator or validator can convert their delegation to a validator into Validator Bond by signing a ValidatorBond message. 
+
+The ValidatorBond message is exposed by the staking module and can be executed as follows:
+```
+gaiad tx staking validator-bond cosmosvaloper13h5xdxhsdaugwdrkusf8lkgu406h8t62jkqv3h <delegator> --from mykey  
+```
+There are no partial Validator Bonds: when a delegator or validator converts their shares to a particular validator into Validator Bond, their entire delegation to that validator is converted to Validator Bond. If a validator or delegator wishes to convert only some of their delegation to Validator Bond, they should transfer those funds to a separate address and Validator Bond from that address.
+
+To convert Validator Bond back into a standard delegation, simply unbond the shares.
+
+### Software parameters
+
+A new governance parameter is introduced that defines the cap on the percentage of delegated shares than can be liquid. This is called the `GlobalLiquidStakingCap`. Additionally, the `ExemptionFactor` has been renamed to `ValidatorBondFactor`
+
+
+
+```proto
+// Params defines the parameters for the staking module.
+message Params {
+  option (gogoproto.equal)            = true;
+  option (gogoproto.goproto_stringer) = false;
+
+  // unbonding_time is the time duration of unbonding.
+  google.protobuf.Duration unbonding_time = 1 [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
+  // max_validators is the maximum number of validators.
+  uint32 max_validators = 2;
+  // max_entries is the max entries for either unbonding delegation or redelegation (per pair/trio).
+  uint32 max_entries = 3;
+  // historical_entries is the number of historical entries to persist.
+  uint32 historical_entries = 4;
+  // bond_denom defines the bondable coin denomination.
+  string bond_denom = 5;
+  // min_commission_rate is the chain-wide minimum commission rate that a validator can charge their delegators
+  string min_commission_rate = 6 [
+    (gogoproto.moretags)   = "yaml:\"min_commission_rate\"",
+    (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Dec",
+    (gogoproto.nullable)   = false
+  ];
+  // validator_bond_factor is required as a safety check for tokenizing shares and 
+  // delegations from liquid staking providers
+  string validator_bond_factor = 7 [
+    (gogoproto.moretags) = "yaml:\"validator_bond_factor\"",
+    (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Dec",
+    (gogoproto.nullable) = false
+  ];
+  // global_liquid_staking_cap represents a cap on the portion of stake that 
+  // comes from liquid staking providers
+  string global_liquid_staking_cap = 8 [
+    (gogoproto.moretags)   = "yaml:\"global_liquid_staking_cap\"",
+    (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Dec",
+    (gogoproto.nullable)   = false
+  ];
+}
+```
+
+### Data structures
+
+#### Validator
+The `Validator` struct had attributes `TotalExemptShares` and `TotalTokenizedShares` renamed to `TotalValidatorBondShares` and `TotalLiquidShares` respectively.
+
+```proto
+// Validator defines a validator, together with the total amount of the
+// Validator's bond shares and their exchange rate to coins. Slashing results in
+// a decrease in the exchange rate, allowing correct calculation of future
+// undelegations without iterating over delegators. When coins are delegated to
+// this validator, the validator is credited with a delegation whose number of
+// bond shares is based on the amount of coins delegated divided by the current
+// exchange rate. Voting power can be calculated as total bonded shares
+// multiplied by exchange rate.
+message Validator {
+  option (gogoproto.equal)            = false;
+  option (gogoproto.goproto_stringer) = false;
+  option (gogoproto.goproto_getters)  = false;
+
+  // operator_address defines the address of the validator's operator; bech encoded in JSON.
+  string operator_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  // consensus_pubkey is the consensus public key of the validator, as a Protobuf Any.
+  google.protobuf.Any consensus_pubkey = 2 [(cosmos_proto.accepts_interface) = "cosmos.crypto.PubKey"];
+  // jailed defined whether the validator has been jailed from bonded status or not.
+  bool jailed = 3;
+  // status is the validator status (bonded/unbonding/unbonded).
+  BondStatus status = 4;
+  // tokens define the delegated tokens (incl. self-delegation).
+  string tokens = 5 [
+    (cosmos_proto.scalar)  = "cosmos.Int",
+    (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Int",
+    (gogoproto.nullable)   = false
+  ];
+  // delegator_shares defines total shares issued to a validator's delegators.
+  string delegator_shares = 6 [
+    (cosmos_proto.scalar)  = "cosmos.Dec",
+    (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Dec",
+    (gogoproto.nullable)   = false
+  ];
+  // description defines the description terms for the validator.
+  Description description = 7 [(gogoproto.nullable) = false];
+  // unbonding_height defines, if unbonding, the height at which this validator has begun unbonding.
+  int64 unbonding_height = 8;
+  // unbonding_time defines, if unbonding, the min time for the validator to complete unbonding.
+  google.protobuf.Timestamp unbonding_time = 9 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
+  // commission defines the commission parameters.
+  Commission commission = 10 [(gogoproto.nullable) = false];
+  // Number of shares self bonded from the validator
+  string total_validator_bond_shares = 11 [
+    (cosmos_proto.scalar)  = "cosmos.Dec",
+    (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Dec",
+    (gogoproto.nullable)   = false
+  ];
+  // Total number of shares either tokenized or owned by a liquid staking provider 
+  string total_liquid_shares = 12 [
+    (cosmos_proto.scalar)  = "cosmos.Dec",
+    (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Dec",
+    (gogoproto.nullable)   = false
+  ];
+}
+```
+
+#### Delegation
+The `Delegation` struct's `Exempt` attribute was renamed to `ValidatorBond`
+
+```proto
+// Delegation represents the bond with tokens held by an account. It is
+// owned by one delegator, and is associated with the voting power of one
+// validator.
+message Delegation {
+  option (gogoproto.equal)            = false;
+  option (gogoproto.goproto_getters)  = false;
+  option (gogoproto.goproto_stringer) = false;
+
+  // delegator_address is the bech32-encoded address of the delegator.
+  string delegator_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  // validator_address is the bech32-encoded address of the validator.
+  string validator_address = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  // shares define the delegation shares received.
+  string shares = 3 [
+    (cosmos_proto.scalar)  = "cosmos.Dec",
+    (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Dec",
+    (gogoproto.nullable)   = false
+  ];
+  // has this delegation been marked as a validator self bond.
+  bool validator_bond = 4;
+}
+```
+
+### Tracking total liquid stake
+To monitor the progress towards the global liquid staking cap, the module needs to know two things: the total amount of staked tokens and the total amount of *liquid staked* tokens. The total staked tokens can be found by checking the balance of the "Bonded" pool. The total *liquid staked* tokens are stored separately and can be found under the `TotalLiquidStakedTokensKey` prefix (`[]byte{0x65}`). The value is managed by the following keeper functions:
+```go
+func (k Keeper) SetTotalLiquidStakedTokens(ctx sdk.Context, tokens sdk.Dec)
+func (k Keeper) GetTotalLiquidStakedTokens(ctx sdk.Context) sdk.Dec
+```
+
+### Helper functions
+In order to identify whether a liquid stake transaction will exceed either the global liquid staking cap or the validator bond cap, the following functions were added:
+
+```go
+// Check if an account is a owned by a liquid staking provider
+// This is determined by checking if the account is a 32-length module account
+func (k Keeper) AccountIsLiquidStakingProvider(ctx sdk.Context, address sdk.AccAddress) bool 
+
+// SafelyIncreaseTotalLiquidStakedTokens increments the total liquid staked tokens
+// if the global cap is enabled and is not surpassed by this delegation
+func (k Keeper) SafelyIncreaseTotalLiquidStakedTokens(ctx sdk.Context, amount sdk.Int) error 
+
+// DecreaseTotalLiquidStakedTokens decrements the total liquid staked tokens
+// if the global cap is enabled
+func (k Keeper) DecreaseTotalLiquidStakedTokens(ctx sdk.Context, amount sdk.Int) 
+
+// SafelyIncreaseValidatorTotalLiquidShares increments the total liquid shares on a validator
+// if the validator bond factor is enabled and is not surpassed by this delegation
+func (k Keeper) SafelyIncreaseValidatorTotalLiquidShares(ctx sdk.Context, validator types.Validator, shares sdk.Dec) error 
+
+// DecreaseValidatorTotalLiquidShares decrements the total liquid shares on a validator
+// if the validator bond factor is enabled
+func (k Keeper) DecreaseValidatorTotalLiquidShares(ctx sdk.Context, validator types.Validator, shares sdk.Dec) 
+
+// SafelyDecreaseValidatorBond decrements the total validator's self bond
+// so long as it will not cause the current delegations to exceed the threshold
+// set by validator bond factor
+func (k Keeper) SafelyDecreaseValidatorBond(ctx sdk.Context, validator types.Validator, shares sdk.Dec) error 
+```
+
+### Accounting
+Tracking the total liquid stake and total liquid validator shares requires additional accounting changes in the following transactions/events:
+
+```go
+func Delegate() {
+    ...
+    // If delegator is a liquid staking provider
+    //    Increment total liquid staked
+    //    Increment validator liquid shares
+}
+
+func Undelegate() {
+    ...
+    // If delegator is a liquid staking provider
+    //    Decrement total liquid staked
+    //    Decrement validator liquid shares
+}
+
+func BeginRedelegate() {
+    ...
+    // If delegator is a liquid staking provider
+    //    Decrement source validator liquid shares
+    //    Increment destination validator liquid shares
+}
+
+func TokenizeShares() {
+    ...
+    // If delegator is a NOT liquid staking provider (otherwise the shares are already included)
+    //    Increment total liquid staked
+    //    Increment validator liquid shares
+}
+
+func RedeemTokens() {
+    ...
+    // If delegator is a NOT liquid staking provider 
+    //    Decrement total liquid staked
+    //    Decrement validator liquid shares
+}
+
+func Slash() {
+    ...
+    // Decrement total liquid staked (since total liquid stake is denominated in tokens, not shares)
+}
+```
+
+### Transaction failure cases
+With the liquid staking caps in consideration, there are additional scenarios that should cause a transaction to fail:
+```go
+
+func Delegate() {
+    ...
+    // If delegator is a liquid staking provider
+    //    Fail transaction if delegation exceeds global liquid staking cap
+    //    Fail transaction if delegation exceeds validator bond cap
+}
+
+func Undelegate() {
+    ...
+    // If the unbonded delegation is a ValidatorBond
+    //    Fail transaction if the reduction in validator bond would cause the
+    //    existing liquid delegation to exceed the cap
+}
+
+func BeginRedelegate() {
+    ...
+    // If the delegation is a ValidatorBond
+    //    Fail transaction if the reduction in validator bond would cause the
+    //    existing liquid delegation to exceed the cap
+
+    // If delegator is a liquid staking provider
+    //    Fail transaction if delegation exceeds global liquid staking cap
+    //    Fail transaction if delegation exceeds validator bond cap
+}
+
+func TokenizeShares() {
+    ...
+    // If the delegation is a ValidatorBond
+    //    Fail transaction - ValidatorBond's cannot be tokenized
+
+    // If the sender is NOT a liquid staking provider
+    //    Fail transaction if tokenized shares would exceed the global liquid staking cap
+    //    Fail transaction if tokenized shares would exceed the validator bond cap
+}
+```
+
+### Tombstoning
+* When a validator is tombstoned, the tombstoned stake can be excluded from the global cap. This requires a small change to the evidence module
+```go
+func HandleEquivocationEvidence() // in evidence keeper
+   ...
+   k.slashingKeeper.Tombstone(ctx, consAddr)
+   k.stakingKeeper.DecreaseTotalLiquidStaked(validator.GetTotalLiquidShares())
+```
+
+### Bootstrapping total liquid stake
+When upgrading to enable the liquid staking module, the total global liquid stake and total liquid validator shares must be determined. This can be done in the upgrade handler by looping through delegation records and including the delegation in the total if the delegator is a module account.


### PR DESCRIPTION
Implementation in #61 

ADR-002 introduces the global liquid staking cap and renames exemption factor to validator bond factor. Delegations from module account and LSM tokenized shares are tracked against the global liquid staking and validator bond caps. This requires changing the standard staking transactions to introspect. The reason for tracking module account shares is because ICAs are module accounts under the hood, so in practice this limits liquid staking.