### PR TITLE
Added RefreshTotalLiquidStaked (for upgrade handler)

### DIFF
--- a/adr/adr-002.md
+++ b/adr/adr-002.md
@@ -339,4 +339,12 @@ func HandleEquivocationEvidence() // in evidence keeper
 ```
 
 ### Bootstrapping total liquid stake
-When upgrading to enable the liquid staking module, the total global liquid stake and total liquid validator shares must be determined. This can be done in the upgrade handler by looping through delegation records and including the delegation in the total if the delegator is a module account.
+When upgrading to enable the liquid staking module, the total global liquid stake and total liquid validator shares must be determined. This can be done in the upgrade handler by looping through delegation records and including the delegation in the total if the delegator is a module account. This is implemented by the following function:
+```go
+func RefreshTotalLiquidStakedTokensAndShares() {
+  // Resets all validator TotalLiquidShares to 0
+  // Loops delegation records
+  //    For each delegation, determines if the delegation was from a module account
+  //    If so, increments the global liquid staking cap and validator liquid shares
+}
+```

--- a/adr/adr-002.md
+++ b/adr/adr-002.md
@@ -341,7 +341,7 @@ func HandleEquivocationEvidence() // in evidence keeper
 ### Bootstrapping total liquid stake
 When upgrading to enable the liquid staking module, the total global liquid stake and total liquid validator shares must be determined. This can be done in the upgrade handler by looping through delegation records and including the delegation in the total if the delegator is a module account. This is implemented by the following function:
 ```go
-func RefreshTotalLiquidStakedTokensAndShares() {
+func RefreshTotalLiquidStaked() {
   // Resets all validator TotalLiquidShares to 0
   // Loops delegation records
   //    For each delegation, determines if the delegation was from a module account

--- a/x/staking/keeper/liquid_stake.go
+++ b/x/staking/keeper/liquid_stake.go
@@ -162,7 +162,7 @@ func (k Keeper) SafelyDecreaseValidatorBond(ctx sdk.Context, validator types.Val
 // under the hood
 // This function must be called in the upgrade handler which onboards LSM, as
 // well as any time the liquid staking cap is re-enabled
-func (k Keeper) RefreshTotalLiquidStakedTokensAndShares(ctx sdk.Context) error {
+func (k Keeper) RefreshTotalLiquidStaked(ctx sdk.Context) error {
 	// First reset each validator's liquid shares to 0
 	for _, validator := range k.GetAllValidators(ctx) {
 		validator.TotalLiquidShares = sdk.ZeroDec()

--- a/x/staking/keeper/liquid_stake.go
+++ b/x/staking/keeper/liquid_stake.go
@@ -155,30 +155,51 @@ func (k Keeper) SafelyDecreaseValidatorBond(ctx sdk.Context, validator types.Val
 	return nil
 }
 
-// Determines the total liquid staked by looping across each delegation record
-// and summing the stake if the delegator is a liquid staking provider
-func (k Keeper) CalculateTotalLiquidStaked(ctx sdk.Context) (sdk.Int, error) {
-	totalLiquidStaked := sdk.ZeroInt()
+// Calculates and sets the global liquid staked tokens and total liquid shares by validator
+// The totals are determined by looping each delegation record and summing the stake
+// if the delegator is a module account. Checking for a module account will capture
+// ICA accounts, as well as tokenized delegationswhich are owned by module accounts
+// under the hood
+// This function must be called in the upgrade handler which onboards LSM, as
+// well as any time the liquid staking cap is re-enabled
+func (k Keeper) RefreshTotalLiquidStakedTokensAndShares(ctx sdk.Context) error {
+	// First reset each validator's liquid shares to 0
+	for _, validator := range k.GetAllValidators(ctx) {
+		validator.TotalLiquidShares = sdk.ZeroDec()
+		k.SetValidator(ctx, validator)
+	}
+
+	// Sum up the total liquid tokens and increment each validator's total liquid shares
+	totalLiquidStakedTokens := sdk.ZeroInt()
 	for _, delegation := range k.GetAllDelegations(ctx) {
 		delegatorAddress, err := sdk.AccAddressFromBech32(delegation.DelegatorAddress)
 		if err != nil {
-			return sdk.ZeroInt(), err
+			return err
 		}
 		validatorAddress, err := sdk.ValAddressFromBech32(delegation.ValidatorAddress)
 		if err != nil {
-			return sdk.ZeroInt(), err
+			return err
 		}
 
 		validator, found := k.GetLiquidValidator(ctx, validatorAddress)
 		if !found {
-			return sdk.ZeroInt(), sdkstaking.ErrNoValidatorFound
+			return sdkstaking.ErrNoValidatorFound
 		}
 
+		// If the account is a liquid staking provider, increment the global number
+		// of liquid staked tokens, and the total liquid shares on the validator
 		if k.AccountIsLiquidStakingProvider(ctx, delegatorAddress) {
-			stakeAmount := validator.TokensFromShares(delegation.Shares).TruncateInt()
-			totalLiquidStaked = totalLiquidStaked.Add(stakeAmount)
+			liquidShares := delegation.Shares
+			liquidTokens := validator.TokensFromShares(liquidShares).TruncateInt()
+
+			validator.TotalLiquidShares = validator.TotalLiquidShares.Add(liquidShares)
+			k.SetValidator(ctx, validator)
+
+			totalLiquidStakedTokens = totalLiquidStakedTokens.Add(liquidTokens)
 		}
 	}
 
-	return totalLiquidStaked, nil
+	k.SetTotalLiquidStakedTokens(ctx, totalLiquidStakedTokens)
+
+	return nil
 }

--- a/x/staking/keeper/liquid_stake_test.go
+++ b/x/staking/keeper/liquid_stake_test.go
@@ -13,6 +13,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Helper function to create a base account from an account name
+// Used to differentiate against liquid staking provider module account
+func createBaseAccount(app *simapp.SimApp, ctx sdk.Context, accountName string) sdk.AccAddress {
+	baseAccountAddress := sdk.AccAddress(accountName)
+	app.AccountKeeper.SetAccount(ctx, authtypes.NewBaseAccountWithAddress(baseAccountAddress))
+	return baseAccountAddress
+}
+
+// Helper function to create a module account from an account name
+// Used to mock an liquid staking provider's ICA account
+func createICAAccount(app *simapp.SimApp, ctx sdk.Context, accountName string) sdk.AccAddress {
+	accountAddress := address.Module(accountName, []byte(accountName))
+	account := authtypes.NewModuleAccount(
+		authtypes.NewBaseAccountWithAddress(accountAddress),
+		accountName,
+	)
+	app.AccountKeeper.SetAccount(ctx, account)
+
+	return accountAddress
+}
+
 // Tests Set/Get TotalLiquidStakedTokens
 func TestTotalLiquidStakedTokens(t *testing.T) {
 	_, app, ctx := createTestInput(t)
@@ -47,18 +68,9 @@ func TestValidatorTotalLiquidShares(t *testing.T) {
 func TestAccountIsLiquidStakingProvider(t *testing.T) {
 	_, app, ctx := createTestInput(t)
 
-	// Create base account
-	baseAccountAddress := sdk.AccAddress("base-account")
-	app.AccountKeeper.SetAccount(ctx, authtypes.NewBaseAccountWithAddress(baseAccountAddress))
-
-	// Create an ICA module account
-	icaModuleAccountName := "ica-account"
-	icaAccountAddress := address.Module(icaModuleAccountName, []byte("ica-module-account"))
-	icaAccount := authtypes.NewModuleAccount(
-		authtypes.NewBaseAccountWithAddress(icaAccountAddress),
-		icaModuleAccountName,
-	)
-	app.AccountKeeper.SetAccount(ctx, icaAccount)
+	// Create base and ICA accounts
+	baseAccountAddress := createBaseAccount(app, ctx, "base-account")
+	icaAccountAddress := createICAAccount(app, ctx, "ica-module-account")
 
 	// Only the ICA module account should be considered a liquid staking provider
 	require.False(t, app.StakingKeeper.AccountIsLiquidStakingProvider(ctx, baseAccountAddress), "base account")
@@ -508,4 +520,162 @@ func TestDecreaseValidatorTotalLiquidShares(t *testing.T) {
 	actualValidator, found = app.StakingKeeper.GetLiquidValidator(ctx, valAddress)
 	require.True(t, found)
 	require.Equal(t, initialLiquidShares.Sub(decreaseAmount), actualValidator.TotalLiquidShares, "shares with cap disabled")
+}
+
+// Test CalculateTotalLiquidStaked
+func TestCalculateTotalLiquidStaked(t *testing.T) {
+	_, app, ctx := createTestInput(t)
+
+	// With no delegations, the total should be 0
+	total, err := app.StakingKeeper.CalculateTotalLiquidStaked(ctx)
+	require.NoError(t, err, "no error expected when calculating total liquid staked")
+	require.Equal(t, int64(0), total.Int64(), "total liquid staked before delegations are created")
+
+	// Add validator's with various exchange rates
+	validators := []types.Validator{
+		{
+			// Exchange rate of 1
+			OperatorAddress: "valA",
+			Tokens:          sdk.NewInt(100),
+			DelegatorShares: sdk.NewDec(100),
+		},
+		{
+			// Exchange rate of 0.9
+			OperatorAddress: "valB",
+			Tokens:          sdk.NewInt(90),
+			DelegatorShares: sdk.NewDec(100),
+		},
+		{
+			// Exchange rate of 0.75
+			OperatorAddress: "valC",
+			Tokens:          sdk.NewInt(75),
+			DelegatorShares: sdk.NewDec(100),
+		},
+	}
+
+	// Add various delegations across the above validator's
+	// Total Liquid Staked: 1,849 + 922 = 2,771
+	expectedTotalLiquidStaked := int64(2771)
+	delegations := []struct {
+		delegation types.Delegation
+		isLSTP     bool
+	}{
+		// Delegator A - Not a liquid staking provider
+		// Number of tokens/shares is irrelevant for this test
+		{
+			isLSTP: false,
+			delegation: types.Delegation{
+				DelegatorAddress: "delA",
+				ValidatorAddress: "valA",
+				Shares:           sdk.NewDec(100),
+			},
+		},
+		{
+			isLSTP: false,
+			delegation: types.Delegation{
+				DelegatorAddress: "delA",
+				ValidatorAddress: "valB",
+				Shares:           sdk.NewDec(860),
+			},
+		},
+		{
+			isLSTP: false,
+			delegation: types.Delegation{
+				DelegatorAddress: "delA",
+				ValidatorAddress: "valC",
+				Shares:           sdk.NewDec(750),
+			},
+		},
+		// Delegator B - Liquid staking provider, tokens included in total
+		// Total liquid staked: 400 + 774 + 675 = 1,849
+		{
+			// Shares: 400 shares, Exchange Rate: 1.0, Tokens: 400
+			isLSTP: true,
+			delegation: types.Delegation{
+				DelegatorAddress: "delB-LSTP",
+				ValidatorAddress: "valA",
+				Shares:           sdk.NewDec(400),
+			},
+		},
+		{
+			// Shares: 860 shares, Exchange Rate: 0.9, Tokens: 774
+			isLSTP: true,
+			delegation: types.Delegation{
+				DelegatorAddress: "delB-LSTP",
+				ValidatorAddress: "valB",
+				Shares:           sdk.NewDec(860),
+			},
+		},
+		{
+			// Shares: 900 shares, Exchange Rate: 0.75, Tokens: 675
+			isLSTP: true,
+			delegation: types.Delegation{
+				DelegatorAddress: "delB-LSTP",
+				ValidatorAddress: "valC",
+				Shares:           sdk.NewDec(900),
+			},
+		},
+		// Delegator C - Liquid staking provider, tokens included in total
+		// Total liquid staked: 325 + 522 + 75 = 922
+		{
+			// Shares: 325 shares, Exchange Rate: 1.0, Tokens: 325
+			isLSTP: true,
+			delegation: types.Delegation{
+				DelegatorAddress: "delC-LSTP",
+				ValidatorAddress: "valA",
+				Shares:           sdk.NewDec(325),
+			},
+		},
+		{
+			// Shares: 580 shares, Exchange Rate: 0.9, Tokens: 522
+			isLSTP: true,
+			delegation: types.Delegation{
+				DelegatorAddress: "delC-LSTP",
+				ValidatorAddress: "valB",
+				Shares:           sdk.NewDec(580),
+			},
+		},
+		{
+			// Shares: 100 shares, Exchange Rate: 0.75, Tokens: 75
+			isLSTP: true,
+			delegation: types.Delegation{
+				DelegatorAddress: "delC-LSTP",
+				ValidatorAddress: "valC",
+				Shares:           sdk.NewDec(100),
+			},
+		},
+	}
+
+	// Create validators based on the above (must use an actual validator address)
+	addresses := simapp.AddTestAddrsIncremental(app, ctx, 5, app.StakingKeeper.TokensFromConsensusPower(ctx, 300))
+	validatorAddresses := map[string]sdk.ValAddress{
+		"valA": sdk.ValAddress(addresses[0]),
+		"valB": sdk.ValAddress(addresses[1]),
+		"valC": sdk.ValAddress(addresses[2]),
+	}
+	for _, validator := range validators {
+		validator.OperatorAddress = validatorAddresses[validator.OperatorAddress].String()
+		app.StakingKeeper.SetValidator(ctx, validator)
+	}
+
+	// Create the delegations based on the above (must use actual delegator addresses)
+	for _, delegationCase := range delegations {
+		var delegatorAddress sdk.AccAddress
+		if delegationCase.isLSTP {
+			delegatorAddress = createICAAccount(app, ctx, delegationCase.delegation.DelegatorAddress)
+		} else {
+			delegatorAddress = createBaseAccount(app, ctx, delegationCase.delegation.DelegatorAddress)
+		}
+
+		delegation := delegationCase.delegation
+		delegation.DelegatorAddress = delegatorAddress.String()
+		delegation.ValidatorAddress = validatorAddresses[delegation.ValidatorAddress].String()
+		app.StakingKeeper.SetDelegation(ctx, delegation)
+	}
+
+	// Check total liquid staked
+	actualTotalLiquidStaked, err := app.StakingKeeper.CalculateTotalLiquidStaked(ctx)
+	require.NoError(t, err, "no error expected when calculating total liquid staked")
+	require.Equal(t, expectedTotalLiquidStaked, actualTotalLiquidStaked.Int64(),
+		"total liquid staked after delegations are created")
 }

--- a/x/staking/keeper/liquid_stake_test.go
+++ b/x/staking/keeper/liquid_stake_test.go
@@ -685,7 +685,7 @@ func TestCalculateTotalLiquidStaked(t *testing.T) {
 	}
 
 	// Refresh the total liquid staked and validator liquid shares
-	err := app.StakingKeeper.RefreshTotalLiquidStakedTokensAndShares(ctx)
+	err := app.StakingKeeper.RefreshTotalLiquidStaked(ctx)
 	require.NoError(t, err, "no error expected when refreshing total liquid staked")
 
 	// Check the total liquid staked and liquid shares by validator

--- a/x/staking/keeper/msg_server_test.go
+++ b/x/staking/keeper/msg_server_test.go
@@ -6,7 +6,6 @@ import (
 	"cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/types/address"
 
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	vesting "github.com/cosmos/cosmos-sdk/x/auth/vesting/exported"
@@ -19,21 +18,6 @@ import (
 	"github.com/iqlusioninc/liquidity-staking-module/x/staking/types"
 	"github.com/stretchr/testify/require"
 )
-
-// helper function to create an ICA account that will be used as the validator
-// returns the address
-func createICAAccount(app *simapp.SimApp, ctx sdk.Context) sdk.AccAddress {
-	icaModuleAccountName := "ica-account"
-	icaAccountAddress := address.Module(icaModuleAccountName, []byte("ica-module-account"))
-
-	icaAccount := authtypes.NewModuleAccount(
-		authtypes.NewBaseAccountWithAddress(icaAccountAddress),
-		icaModuleAccountName,
-	)
-	app.AccountKeeper.SetAccount(ctx, icaAccount)
-
-	return icaAccountAddress
-}
 
 func TestTokenizeSharesAndRedeemTokens(t *testing.T) {
 	_, app, ctx := createTestInput(t)
@@ -287,7 +271,7 @@ func TestTokenizeSharesAndRedeemTokens(t *testing.T) {
 			addrVal1, addrVal2 := sdk.ValAddress(addrAcc1), sdk.ValAddress(addrAcc2)
 
 			// Create ICA module account
-			icaAccountAddress := createICAAccount(app, ctx)
+			icaAccountAddress := createICAAccount(app, ctx, "ica-module-account")
 
 			// Fund module account
 			delegationCoin := sdk.NewCoin(app.StakingKeeper.BondDenom(ctx), tc.delegationAmount)
@@ -634,7 +618,7 @@ func TestValidatorBond(t *testing.T) {
 
 			delegatorAddress := sdk.AccAddress(delegatorPubKey.Address())
 			validatorAddress := sdk.ValAddress(validatorPubKey.Address())
-			icaAccountAddress := createICAAccount(app, ctx)
+			icaAccountAddress := createICAAccount(app, ctx, "ica-module-account")
 
 			// Set the delegator address to either be a user account or an ICA account depending on the test case
 			if tc.delegatorIsLSTP {


### PR DESCRIPTION
## Context

In the upgrade handler that onboards LSM, we'll have to bootstrap the total liquid staked tokens and shares. This PR introduces a function `RefreshTotalLiquidStakedTokensAndShares` that can be called from the upgrade handler, or any time the global cap is re-enabled.

## Changelog
* Added `RefreshTotalLiquidStakedTokensAndShares` that:
  * Resets each validator's `TotalLiquidShares` to 0
  * Iterates delegation records owned by module accounts
  * Updates each validator's `TotalLiquidShares` as well as the global `TotalLiquidStakedTokens`
* Added corresponding unit tests
