### PR TITLE
Update dependabot.yml to use master branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    target-branch: "main"
+    target-branch: "master"
     open-pull-requests-limit: 10
     labels:
       - dependencies
@@ -13,7 +13,7 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    target-branch: "main"
+    target-branch: "master"
     open-pull-requests-limit: 10
     labels:
       - dependencies


### PR DESCRIPTION
Dependabot was targeting main but we are using `master` here.  

I think the PR's will be automatically updated after we merge this. 