### PR TITLE
ensure that v0.45.16-ics passes the linter

### DIFF
--- a/x/distribution/simulation/operations_test.go
+++ b/x/distribution/simulation/operations_test.go
@@ -235,7 +235,7 @@ func (suite *SimTestSuite) SetupTest() {
 	suite.genesisVals = genesisVals
 }
 
-func (suite *SimTestSuite) getTestingAccounts(r *rand.Rand, n int) []simtypes.Account {
+func (suite *SimTestSuite) getTestingAccounts(r *rand.Rand, n int) []simtypes.Account { //nolint:unparam // n always receives 3, but it might be used differently in the future.
 	accounts := simtypes.RandomAccounts(r, n)
 
 	initAmt := suite.app.StakingKeeper.TokensFromConsensusPower(suite.ctx, 200)

--- a/x/staking/keeper/grpc_query.go
+++ b/x/staking/keeper/grpc_query.go
@@ -540,7 +540,7 @@ func queryAllRedelegations(store sdk.KVStore, k Querier, req *types.QueryRedeleg
 }
 
 // Query for individual tokenize share record information by share by id
-func (k Querier) TokenizeShareRecordById(c context.Context, req *types.QueryTokenizeShareRecordByIdRequest) (*types.QueryTokenizeShareRecordByIdResponse, error) {
+func (k Querier) TokenizeShareRecordById(c context.Context, req *types.QueryTokenizeShareRecordByIdRequest) (*types.QueryTokenizeShareRecordByIdResponse, error) { //nolint:revive // fixing this would require changing the .proto files, so we might as well leave it alone
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
@@ -605,7 +605,7 @@ func (k Querier) AllTokenizeShareRecords(c context.Context, req *types.QueryAllT
 }
 
 // Query for last tokenize share record id
-func (k Querier) LastTokenizeShareRecordId(c context.Context, req *types.QueryLastTokenizeShareRecordIdRequest) (*types.QueryLastTokenizeShareRecordIdResponse, error) {
+func (k Querier) LastTokenizeShareRecordId(c context.Context, req *types.QueryLastTokenizeShareRecordIdRequest) (*types.QueryLastTokenizeShareRecordIdResponse, error) { //nolint:revive // fixing this would require changing the .proto files, so we might as well leave it alone
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}


### PR DESCRIPTION
This PR ensures that the v0.45.16-ics version of the LSM passes golangci-lint. 